### PR TITLE
Fixed setup.py for install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        "boto3"
-        "lxml"
+        "boto3",
+        "lxml",
         "numpy",
         "pandas",
         "pillow",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
         "numpy",
         "pandas",
         "pillow",
-        "requests"
-        "tqdm"
+        "requests",
+        "tqdm",
     ],
 )


### PR DESCRIPTION
Missing commas in the install_requires section were impeding a successful install.

Relevant to issue #4 