### PR TITLE
Darknet support for download of OpenImages

### DIFF
--- a/cvdata/resize.py
+++ b/cvdata/resize.py
@@ -239,6 +239,9 @@ def resize_image(
                 for line in original_kitti_file:
                     new_kitti_file.write(scale_line(line, new_width, new_height, scale_x, scale_y))
 
+    else:
+        raise ValueError(f"Unsupported annotation format: \'{annotation_format}\'")
+
     return 0
 
 
@@ -267,8 +270,8 @@ def resize_images(
     :return: the number of resized image/annotation files
     """
 
-    # only allow for PASCAL format
-    if annotation_format != "pascal":
+    # only allow for KITTI and PASCAL annotation formats
+    if annotation_format not in ["kitti", "pascal"]:
         raise ValueError(f"Unsupported annotation format: {annotation_format}")
     else:
         annotation_ext = _FORMAT_EXTENSIONS[annotation_format]

--- a/cvdata/utils.py
+++ b/cvdata/utils.py
@@ -1,5 +1,24 @@
 import os
 
+import PIL.Image as Image
+
+
+# ------------------------------------------------------------------------------
+def image_dimensions(
+        image_file_path: str,
+) -> (int, int, int):
+    """
+    Gets an image's width, height, and depth dimensions.
+
+    :param image_file_path: absolute path to an image file
+    :return: the image's width, height, and depth
+    """
+
+    image = Image.open(image_file_path)
+    img_width, img_height = image.size
+    img_depth = image.layers
+    return img_width, img_height, img_depth
+
 
 # ------------------------------------------------------------------------------
 def matching_ids(

--- a/cvdata/visualize.py
+++ b/cvdata/visualize.py
@@ -54,7 +54,8 @@ def bbox_darknet(
     :param width: width of the corresponding image
     :param height: height of the corresponding image
     :return: list of bounding box dictionary objects with keys "label", "x",
-        "y", "w", and "h"
+        "y", "w", and "h", values are percentages between 0.0 and 1.0, and the X
+        and Y values are for the center of the box
     """
 
     boxes = []
@@ -241,14 +242,6 @@ def bbox_pascal(
 
 
 # ------------------------------------------------------------------------------
-def get_image_file_name(pascal_file_path: str) -> str:
-
-    tree = ElementTree.parse(pascal_file_path)
-    root = tree.getroot()
-    return root.find("filename").text
-
-
-# ------------------------------------------------------------------------------
 if __name__ == "__main__":
 
     # Visualize images with bounding boxes specified by corresponding annotations.
@@ -289,14 +282,10 @@ if __name__ == "__main__":
 
         count += 1
 
-        if args["format"] == "pascal":
-            # get the corresponding image file name from the annotation file
-            image_file_name = get_image_file_name(
-                os.path.join(args["annotations_dir"], annotation_file_name),
-            )
-        else:
-            # we assume each annotation shares the same base name as the corresponding image
-            image_file_name = os.path.splitext(annotation_file_name)[0] + ".jpg"
+        # we assume each annotation shares the same base name as the corresponding image
+        annotations_file_path = \
+            os.path.join(args["annotations_dir"], annotation_file_name)
+        image_file_name = os.path.splitext(annotation_file_name)[0] + ".jpg"
 
         # load the input image from disk to determine the dimensions
         image_file_path = \
@@ -310,8 +299,7 @@ if __name__ == "__main__":
 
         # read the bounding boxes from the annotation file
         bboxes = []
-        annotations_file_path = \
-            os.path.join(args["annotations_dir"], annotation_file_name)
+
         if args["format"] == "coco":
             if annotation_file_name.endswith(".json"):
                 bboxes = bbox_coco(annotations_file_path)


### PR DESCRIPTION
Now able to download images from OpenImages with annotations in Darknet format.

Resolves issue #14 