### PR TITLE
New CLI that allows for resizing images only

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ $ python resize.py --input_images /ssd_training/kitti/image_2 \
     --width 1024 --height 768 --format kitti
 ```
 
+We can also resize all images in a directory by using the same command as above 
+but without an annotation directory, extension, or format specified:
+```bash
+$ python resize.py --input_images /ssd_training/kitti/image_2 \
+    --output_images /ssd_training/kitti/image_2 \
+    --width 1024 --height 768
+```
+
 ## Convert annotation formats
 In order to convert from one annotation format to another use the script 
 `cvdata/convert.py`. This script currently supports converting annotations from 

--- a/cvdata/resize.py
+++ b/cvdata/resize.py
@@ -84,7 +84,7 @@ def _get_resized_image(
 
 
 # ------------------------------------------------------------------------------
-def _resize_image(arguments: Dict):
+def _resize_image_label(arguments: Dict):
     """
     Wrapper function to be used for mapping to an iterable of arguments that
     will be passed to the resizing function.
@@ -93,7 +93,7 @@ def _resize_image(arguments: Dict):
     :return:
     """
 
-    resize_image(
+    resize_image_label(
         arguments["file_id"],
         arguments["image_ext"],
         arguments["annotation_ext"],
@@ -108,7 +108,64 @@ def _resize_image(arguments: Dict):
 
 
 # ------------------------------------------------------------------------------
+def _resize_image(arguments: Dict):
+    """
+    Wrapper function to be used for mapping to an iterable of arguments that
+    will be passed to the resizing function.
+
+    :param arguments:
+    :return:
+    """
+
+    resize_image(
+        arguments["file_name"],
+        arguments["input_images_dir"],
+        arguments["output_images_dir"],
+        arguments["new_width"],
+        arguments["new_height"],
+    )
+
+
+# ------------------------------------------------------------------------------
 def resize_image(
+        file_name: str,
+        input_images_dir: str,
+        output_images_dir: str,
+        new_width: int,
+        new_height: int,
+) -> int:
+    """
+    Resizes an image.
+
+    :param file_name: file name of the image file
+    :param input_images_dir: directory where image file is located
+    :param output_images_dir: directory where the resized image file
+        should be written
+    :param new_width: new width to which the image should be resized
+    :param new_height: new height to which the image should be resized
+    :return: 0 to indicate successful completion
+    """
+
+    # read the image data into a numpy array and get the dimensions
+    image_path = os.path.join(input_images_dir, file_name)
+    image = cv2.imread(image_path, cv2.IMREAD_UNCHANGED)
+    original_height, original_width = image.shape[:2]
+
+    # resize if necessary
+    if (original_width != new_width) or (original_height != new_height):
+        image, scale_x, scale_y = _get_resized_image(image, new_width, new_height)
+    else:
+        scale_x = scale_y = 1.0
+
+    # write the scaled/padded image to file in the output directory
+    resized_image_path = os.path.join(output_images_dir, file_name)
+    cv2.imwrite(resized_image_path, image)
+
+    return 0
+
+
+# ------------------------------------------------------------------------------
+def resize_image_label(
         file_id: str,
         image_ext: str,
         annotation_ext: str,
@@ -240,7 +297,7 @@ def resize_image(
 
 
 # ------------------------------------------------------------------------------
-def resize_images(
+def resize_dataset(
         input_images_dir: str,
         input_annotations_dir: str,
         output_images_dir: str,
@@ -308,6 +365,49 @@ def resize_images(
         _logger.info("Resizing files")
 
         # use the executor to map the download function to the iterable of arguments
+        list(tqdm(executor.map(_resize_image_label, resize_arguments_list),
+                  total=len(resize_arguments_list)))
+
+
+# ------------------------------------------------------------------------------
+def resize_images(
+        input_images_dir: str,
+        output_images_dir: str,
+        new_width: int,
+        new_height: int,
+):
+    """
+    Resizes all images and corresponding annotations located within the
+    specified directories.
+
+    :param input_images_dir: directory where image files are located
+    :param output_images_dir: directory where resized image files should be written
+    :param new_width: new width to which the image should be resized
+    :param new_height: new height to which the image should be resized
+    :return: the number of resized image/annotation files
+    """
+
+    # create the destination directories in case they don't already exist
+    os.makedirs(output_images_dir, exist_ok=True)
+
+    resize_arguments_list = []
+    for file_name in os.listdir(input_images_dir):
+        if file_name.endswith(".jpg") or file_name.endswith(".png"):
+            resize_arguments = {
+                "file_name": file_name,
+                "input_images_dir": input_images_dir,
+                "output_images_dir": output_images_dir,
+                "new_width": new_width,
+                "new_height": new_height,
+            }
+            resize_arguments_list.append(resize_arguments)
+
+    # use a ProcessPoolExecutor to download the images in parallel
+    with concurrent.futures.ProcessPoolExecutor() as executor:
+
+        _logger.info("Resizing files")
+
+        # use the executor to map the download function to the iterable of arguments
         list(tqdm(executor.map(_resize_image, resize_arguments_list),
                   total=len(resize_arguments_list)))
 
@@ -331,13 +431,13 @@ if __name__ == "__main__":
     )
     args_parser.add_argument(
         "--input_annotations",
-        required=True,
+        required=False,
         type=str,
         help="directory path of original annotations",
     )
     args_parser.add_argument(
         "--output_annotations",
-        required=True,
+        required=False,
         type=str,
         help="directory path of resized annotations",
     )
@@ -363,12 +463,22 @@ if __name__ == "__main__":
     )
     args = vars(args_parser.parse_args())
 
-    resize_images(
-        args["input_images"],
-        args["input_annotations"],
-        args["output_images"],
-        args["output_annotations"],
-        args["width"],
-        args["height"],
-        args["format"],
-    )
+    if args["input_annotations"] is None:
+
+        resize_images(
+            args["input_images"],
+            args["output_images"],
+            args["width"],
+            args["height"],
+        )
+
+    else:
+        resize_dataset(
+            args["input_images"],
+            args["input_annotations"],
+            args["output_images"],
+            args["output_annotations"],
+            args["width"],
+            args["height"],
+            args["format"],
+        )

--- a/cvdata/resize.py
+++ b/cvdata/resize.py
@@ -415,6 +415,23 @@ def resize_images(
 # ------------------------------------------------------------------------------
 if __name__ == "__main__":
 
+    # Example usages:
+    #
+    # Resize all images in a specified directory:
+    #
+    # $ python resize.py --input_images /ssd_training/kitti/image_2 \
+    #     --output_images /ssd_training/kitti/image_2 \
+    #     --width 1024 --height 768
+    #
+    #
+    # Resize images and update the corresponding annotations:
+    #
+    # $ python resize.py --input_images /ssd_training/kitti/image_2 \
+    #     --input_annotations /ssd_training/kitti/label_2 \
+    #     --output_images /ssd_training/kitti/image_2 \
+    #     --output_annotations /ssd_training/kitti/label_2 \
+    #     --width 1024 --height 768 --format kitti
+
     # parse the command line arguments
     args_parser = argparse.ArgumentParser()
     args_parser.add_argument(
@@ -465,6 +482,7 @@ if __name__ == "__main__":
 
     if args["input_annotations"] is None:
 
+        # resize only images
         resize_images(
             args["input_images"],
             args["output_images"],
@@ -473,6 +491,8 @@ if __name__ == "__main__":
         )
 
     else:
+
+        # resize images and modify corresponding annotation files accordingly
         resize_dataset(
             args["input_images"],
             args["input_annotations"],


### PR DESCRIPTION
We can now resize images only via the CLI of the `cvdata.resize.py` module.

Resolves issue #51 