### PR TITLE
Additional TFRecord support

### DIFF
--- a/cvdata/convert.py
+++ b/cvdata/convert.py
@@ -218,11 +218,7 @@ def _to_tfrecord(
     for filename, x in zip(groupby.groups.keys(), groupby.groups):
         filename_groups.append(data(filename, groupby.get_group(x)))
 
-    # with tf.io.TFRecordWriter(tfrecord_path) as tfrecord_writer:
-    #     for group in filename_groups:
-    #         tf_example = _create_tf_example(label_indices, group, images_dir)
-    #         tfrecord_writer.write(tf_example.SerializeToString())
-
+    # write the TFRecords into the specified number of "shard" files
     with contextlib2.ExitStack() as tf_record_close_stack:
         output_tfrecords = \
             tf_record_creation_util.open_sharded_output_tfrecords(

--- a/cvdata/convert.py
+++ b/cvdata/convert.py
@@ -136,10 +136,8 @@ def _create_tf_example(
     """
 
     # read the image into a bytes object, get the dimensions
-    with tf.io.gfile.GFile(os.path.join(images_dir, group.filename), 'rb') as image_file:
-        encoded_jpg = image_file.read()
-    encoded_jpg_io = io.BytesIO(encoded_jpg)
-    image = Image.open(encoded_jpg_io)
+    image = Image.open(os.path.join(images_dir, group.filename))
+    img_bytes = image.tobytes()
     width, height = image.size
 
     # lists of bounding box values for the example
@@ -152,9 +150,9 @@ def _create_tf_example(
     classes_text = []
     classes = []
 
-    # for each bounding box annotation add values to the lists
+    # for each bounding box annotation add the values into the lists
     for index, row in group.object.iterrows():
-        # normalize (between 0.0 and 1.0) the bounding box coordinates
+        # normalize the bounding box coordinates to within the range (0, 1)
         xmins.append(int(row['xmin']) / width)
         xmaxs.append(int(row['xmax']) / width)
         ymins.append(int(row['ymin']) / height)
@@ -169,7 +167,7 @@ def _create_tf_example(
         'image/width': dataset_util.int64_feature(width),
         'image/filename': dataset_util.bytes_feature(filename),
         'image/source_id': dataset_util.bytes_feature(filename),
-        'image/encoded': dataset_util.bytes_feature(encoded_jpg),
+        'image/encoded': dataset_util.bytes_feature(img_bytes),
         'image/format': dataset_util.bytes_feature(image_format),
         'image/object/bbox/xmin': dataset_util.float_list_feature(xmins),
         'image/object/bbox/xmax': dataset_util.float_list_feature(xmaxs),

--- a/cvdata/convert.py
+++ b/cvdata/convert.py
@@ -227,7 +227,7 @@ def _to_tfrecord(
         output_tfrecords = \
             tf_record_creation_util.open_sharded_output_tfrecords(
                 tf_record_close_stack,
-                annotations_dir,
+                tfrecord_path,
                 total_shards,
             )
         for index, group in enumerate(filename_groups):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ boto3==1.10.28
 botocore==1.13.28
 certifi==2019.9.11
 chardet==3.0.4
+contextlib2==0.6.0.post1
 docutils==0.15.2
 filelock==3.0.10
 idna==2.8
@@ -23,6 +24,7 @@ pytz==2019.3
 requests==2.22.0
 s3transfer==0.2.1
 six==1.13.0
+tensorflow==1.15.0
 toml==0.10.0
 tox==3.14.1
 tqdm==4.39.0

--- a/setup.py
+++ b/setup.py
@@ -28,12 +28,14 @@ setuptools.setup(
     ],
     install_requires=[
         "boto3",
+        "contextlib2",
         "lxml",
         "numpy",
         "opencv-python",
         "pandas",
         "pillow",
         "requests",
+        'tensorflow',
         "tqdm",
     ],
 )


### PR DESCRIPTION
Added support for conversion of KITTI and PASCAL datasets into TFRecords, and added visualization for TFRecords that use the TFRecord format specified for TensorFlow object detection model training.

Resolves issues #78 and #80 