### PR TITLE
fix split bug for replace_labels

### DIFF
--- a/src/cvdata/clean.py
+++ b/src/cvdata/clean.py
@@ -485,7 +485,7 @@ def main():
     replacements = None
     if args["replace_labels"]:
         replacements = {}
-        for replace_labels in args["replace_labels"].split():
+        for replace_labels in args["replace_labels"]:
             from_label, to_label = replace_labels.split(":")
             replacements[from_label] = to_label
 


### PR DESCRIPTION
The replace_labels option for the clean script was bugged, it was using a non necessary string split method, since the parameter is already parsed as a list by the argparser.