### PR TITLE
Fix edge case with annotation resizing

### DIFF
--- a/src/cvdata/resize.py
+++ b/src/cvdata/resize.py
@@ -256,11 +256,11 @@ def resize_image_label(
 
             # clip to one less pixel than the dimension size in
             # case the scaling takes us all the way to the edge
-            new_xmax = min((new_width - 1), int(int(xmax.text) * scale_x))
-            new_ymax = min((new_height - 1), int(int(ymax.text) * scale_y))
+            new_xmax = min((new_width - 1), int(int(float(xmax.text)) * scale_x))
+            new_ymax = min((new_height - 1), int(int(float(ymax.text)) * scale_y))
 
-            xmin.text = str(int(int(xmin.text) * scale_x))
-            ymin.text = str(int(int(ymin.text) * scale_y))
+            xmin.text = str(int(int(float(xmin.text)) * scale_x))
+            ymin.text = str(int(int(float(ymin.text)) * scale_y))
             xmax.text = str(new_xmax)
             ymax.text = str(new_ymax)
 


### PR DESCRIPTION
```
%%bash

wget http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCtrainval_11-May-2012.tar
tar xf VOCtrainval_11-May-2012.tar
```

```
unconverted_train_image_folder = "VOCdevkit/VOC2012/JPEGImages/"
unconverted_train_annot_folder = "VOCdevkit/VOC2012/Annotations/"

train_image_folder = 'data/train/image/'
train_annot_folder = 'data/train/annotation/'
```

```
!cvdata_resize --input_images $unconverted_train_image_folder \
    --input_annotations $unconverted_train_annot_folder \
    --output_images $train_image_folder \
    --output_annotations $train_annot_folder \
    --width $IMAGE_W --height $IMAGE_H --format pascal
```